### PR TITLE
Allow Rails 8.x

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     active_record_rate_limiter (1.0.1)
-      rails (~> 7.1)
+      rails (>= 7.1, < 9)
       with_advisory_lock (~> 5.3)
 
 GEM

--- a/active_record_rate_limiter.gemspec
+++ b/active_record_rate_limiter.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
   s.test_files = Dir["spec/**/*"]
 
-  s.add_dependency "rails", "~> 7.1"
+  s.add_dependency "rails", ">= 7.1", "< 9"
   s.add_dependency "with_advisory_lock", "~> 5.3"
 
   s.add_development_dependency "sqlite3", "~> 2.4"

--- a/lib/generators/active_record_rate_limiter/templates/install_active_record_rate_limiter.rb
+++ b/lib/generators/active_record_rate_limiter/templates/install_active_record_rate_limiter.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class InstallActiveRecordRateLimiter < ActiveRecord::Migration
+class InstallActiveRecordRateLimiter < ActiveRecord::Migration[7.1]
 
   def change
     create_table :rate_limited_events do |t|


### PR DESCRIPTION
## Summary
Relax the gemspec's `rails` constraint from `~> 7.1` to `>= 7.1, < 9` so consumers can resolve against Rails 8. The gem's actual AR surface is minimal (one `< ActiveRecord::Base` and one `< ActiveRecord::Migration` reference); no API changes needed for 8.0 compatibility.

Motivated by the Rails 7.2 → 8.0 upgrade in shiplify/tariffizer.